### PR TITLE
Gracefully handle HTTP 429 (token retry/backoff + keep last data)

### DIFF
--- a/custom_components/ostrom/auth.py
+++ b/custom_components/ostrom/auth.py
@@ -1,52 +1,111 @@
 import aiohttp
+import asyncio
 import logging
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
 _LOGGER = logging.getLogger(__name__)
 
 AUTH_URL_TEMPLATE = "https://auth.{env_prefix}/oauth2/token"
 ME_URL_TEMPLATE = "https://{env_prefix}/me"  # Note: this URL format needs to match the API
 
-async def get_access_token(client_id: str, client_secret: str, environment: str) -> Dict[str, Any]:
-    """Get access token from Ostrom API asynchronously."""
+# Retry settings for transient rate limiting (HTTP 429) on the token endpoint.
+# Waits roughly 5s, 15s, 45s between attempts (capped), honouring Retry-After
+# when the server provides it. This lets a cold start survive a short 429 burst
+# instead of immediately leaving all sensors unavailable.
+_TOKEN_MAX_ATTEMPTS = 4
+_TOKEN_BACKOFF_BASE = 5   # seconds
+_TOKEN_BACKOFF_CAP = 120  # seconds
+
+
+async def get_access_token(client_id: str, client_secret: str, environment: str) -> Optional[Dict[str, Any]]:
+    """Get access token from Ostrom API asynchronously.
+
+    Retries with exponential backoff on HTTP 429 (rate limit) and transient
+    network errors. Returns None if no token could be obtained.
+    """
     env_prefix = "sandbox.ostrom-api.io" if environment == "sandbox" else "production.ostrom-api.io"
     auth_url = AUTH_URL_TEMPLATE.format(env_prefix=env_prefix)
     me_url = ME_URL_TEMPLATE.format(env_prefix=env_prefix)
-    
+
     auth = aiohttp.BasicAuth(client_id, client_secret)
     payload = {"grant_type": "client_credentials"}
 
     async with aiohttp.ClientSession() as session:
-        try:
-            # Get token
-            async with session.post(auth_url, auth=auth, data=payload) as response:
-                response.raise_for_status()
-                data = await response.json()
-                access_token = data.get("access_token")
-                expires_in = data.get("expires_in", 3600)
-                
-                if not access_token:
-                    _LOGGER.error("Access token not found in the response: %s", data)
-                    return None
-                
-                # Validate token
-                headers = {"Authorization": f"Bearer {access_token}"}
-                async with session.get(me_url, headers=headers) as me_response:
-                    if me_response.status != 200:
-                        error_text = await me_response.text()
+        for attempt in range(1, _TOKEN_MAX_ATTEMPTS + 1):
+            try:
+                # Get token
+                async with session.post(auth_url, auth=auth, data=payload) as response:
+                    # Handle rate limiting explicitly so we can back off and retry.
+                    if response.status == 429:
+                        retry_after = response.headers.get("Retry-After")
+                        if retry_after is not None and str(retry_after).isdigit():
+                            delay = min(int(retry_after), _TOKEN_BACKOFF_CAP)
+                        else:
+                            delay = min(_TOKEN_BACKOFF_BASE * (3 ** (attempt - 1)), _TOKEN_BACKOFF_CAP)
+
+                        if attempt < _TOKEN_MAX_ATTEMPTS:
+                            _LOGGER.warning(
+                                "Ostrom token endpoint rate limited (HTTP 429), "
+                                "attempt %s/%s. Retrying in %s s.",
+                                attempt, _TOKEN_MAX_ATTEMPTS, delay,
+                            )
+                            await asyncio.sleep(delay)
+                            continue
+
                         _LOGGER.error(
-                            "Validation with /me endpoint failed. Status: %s, Response: %s",
-                            me_response.status,
-                            error_text
+                            "Ostrom token endpoint still rate limited (HTTP 429) "
+                            "after %s attempts. Giving up for this cycle.",
+                            _TOKEN_MAX_ATTEMPTS,
                         )
                         return None
-                
-                _LOGGER.debug("Access token validated successfully")
-                return {"access_token": access_token, "expires_in": expires_in}
-                
-        except aiohttp.ClientError as e:
-            _LOGGER.error("Error during API request: %s", str(e))
-            return None
+
+                    response.raise_for_status()
+                    data = await response.json()
+                    access_token = data.get("access_token")
+                    expires_in = data.get("expires_in", 3600)
+
+                    if not access_token:
+                        _LOGGER.error("Access token not found in the response: %s", data)
+                        return None
+
+                    # Validate token
+                    headers = {"Authorization": f"Bearer {access_token}"}
+                    async with session.get(me_url, headers=headers) as me_response:
+                        if me_response.status != 200:
+                            error_text = await me_response.text()
+                            _LOGGER.error(
+                                "Validation with /me endpoint failed. Status: %s, Response: %s",
+                                me_response.status,
+                                error_text
+                            )
+                            return None
+
+                    _LOGGER.debug("Access token validated successfully")
+                    return {"access_token": access_token, "expires_in": expires_in}
+
+            except aiohttp.ClientResponseError as e:
+                # Non-429 HTTP error (e.g. 401/403/500): retrying will not help.
+                _LOGGER.error("HTTP error from Ostrom auth endpoint: %s", str(e))
+                return None
+
+            except (aiohttp.ClientConnectionError, asyncio.TimeoutError) as e:
+                # Transient network/timeout error: back off and retry.
+                _LOGGER.warning(
+                    "Network/timeout error contacting Ostrom auth endpoint "
+                    "(attempt %s/%s): %s",
+                    attempt, _TOKEN_MAX_ATTEMPTS, str(e),
+                )
+                if attempt < _TOKEN_MAX_ATTEMPTS:
+                    await asyncio.sleep(_TOKEN_BACKOFF_BASE)
+                    continue
+                return None
+
+            except aiohttp.ClientError as e:
+                _LOGGER.error("Error during API request: %s", str(e))
+                return None
+
+    return None
+
 
 def validate_auth(client_id: str, client_secret: str, environment: str) -> bool:
     """Synchronous validation for config flow."""
@@ -56,16 +115,16 @@ def validate_auth(client_id: str, client_secret: str, environment: str) -> bool:
     try:
         if platform.system() == "Windows":
             asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-        
+
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
-        
+
         try:
             result = loop.run_until_complete(get_access_token(client_id, client_secret, environment))
             return result is not None and "access_token" in result
         finally:
             loop.close()
-            
+
     except Exception as e:
         _LOGGER.error("Auth validation failed: %s", str(e))
-        return False 
+        return False

--- a/custom_components/ostrom/sensor.py
+++ b/custom_components/ostrom/sensor.py
@@ -176,9 +176,49 @@ class OstromDataCoordinator(DataUpdateCoordinator):
 
             _LOGGER.debug("Successfully updated Ostrom price data")
             return processed_data
+        except aiohttp.ClientResponseError as err:
+            if err.status == 429:
+                _LOGGER.warning(
+                    "Ostrom API rate limit reached (HTTP 429). "
+                    "Keeping last valid data if available."
+                )
+                if self.data is not None:
+                    return self.data
+
+            _LOGGER.error(
+                "HTTP error while fetching Ostrom data: %s",
+                err,
+                exc_info=True,
+            )
+            raise UpdateFailed(f"HTTP error fetching Ostrom data. {err}") from err
+
+        except (aiohttp.ClientError, asyncio.TimeoutError) as err:
+            _LOGGER.warning(
+                "Network or timeout error while fetching Ostrom data: %s",
+                err,
+                exc_info=True,
+            )
+
+            if self.data is not None:
+                _LOGGER.warning("Keeping last valid Ostrom data despite the error")
+                return self.data
+
+            raise UpdateFailed(f"Network error fetching Ostrom data: {err}") from err
+
         except Exception as err:
-            _LOGGER.error("Error updating Ostrom price data: %s", err, exc_info=True)
-            raise UpdateFailed(f"Error fetching data: {err}") from err
+            _LOGGER.error(
+                "Unexpected error updating Ostrom price data",
+                exc_info=True,
+            )
+
+            if self.data is not None:
+                _LOGGER.warning(
+                    "Unexpected error, but cached Ostrom data is available. "
+                    "Continuing with last known values."
+                )
+                return self.data
+
+            raise UpdateFailed(f"Unexpected error fetching Ostrom data: {err}") from err
 
     def _process_price_data(self, prices) -> PowerPriceData:
         """Process the raw price data into PowerPriceData structure."""


### PR DESCRIPTION
## Problem

The Ostrom auth endpoint (`auth.production.ostrom-api.io/oauth2/token`) intermittently returns **HTTP 429 (Too Many Requests)**. When that happens:

- `auth.get_access_token()` returns `None`, so `_get_access_token()` raises `TypeError: 'NoneType' object is not subscriptable`.
- The coordinator update fails and **all Ostrom sensors become `unavailable`**, which in turn breaks any downstream template sensors / automations that consume the prices.

This is the problem reported in #14 (several users affected).

## Changes

**`auth.py` — retry with backoff on 429**
- `get_access_token()` now retries the token request up to 4 times with exponential backoff, honouring the server's `Retry-After` header when present.
- Non-429 HTTP errors (e.g. 401) fail fast; transient network/timeout errors are retried.
- This lets a cold start (e.g. right after a restart) survive a short 429 burst instead of immediately leaving every sensor unavailable.

**`sensor.py` — keep last valid data on error**
- In `_async_update_data()`, instead of always raising `UpdateFailed`, the coordinator now returns the last cached `self.data` on 429 / network / unexpected errors when data is already available. Sensors stay on their last known values rather than going `unavailable`.
- Credit for this approach to @derjoerg, who proposed it in #14.

## Notes

- No change to the default `SCAN_INTERVAL_MIN` (kept at 10).
- Tested on a live Home Assistant install: after a restart the first token request hit 429, was retried after the server's `Retry-After`, succeeded on the second attempt, and the sensors have stayed stable since (no more `unavailable` flapping, even when the occasional 429 still appears in the log).

Addresses #14.