### PR TITLE
Fix Ostrom price fetch to cover full tomorrow day

### DIFF
--- a/custom_components/ostrom/sensor.py
+++ b/custom_components/ostrom/sensor.py
@@ -261,9 +261,10 @@ class OstromDataCoordinator(DataUpdateCoordinator):
         url = f"https://{self._env_prefix}/spot-prices"
         
         headers = {"Authorization": f"Bearer {self._access_token}"}
+        tomorrow_end = (now + timedelta(days=2)).replace(hour=0, minute=0, second=0, microsecond=0)
         params = {
-            "startDate": now.strftime("%Y-%m-%dT%H:00:00.000Z"),  
-            "endDate": (now + timedelta(days=1)).strftime("%Y-%m-%dT%H:00:00.000Z"),
+            "startDate": now.strftime("%Y-%m-%dT%H:00:00.000Z"),
+            "endDate": tomorrow_end.strftime("%Y-%m-%dT%H:00:00.000Z"),
             "resolution": "HOUR",
             "zip": self.zip_code
         }


### PR DESCRIPTION
The `_fetch_prices` method was requesting prices with endDate set to now + 24h, which means it only returns prices up to the current hour the next day. This leaves the last hours of tomorrow missing from the sensor data.

For example: at 19:00, only prices from 19:00 today to 19:00 tomorrow are returned — prices from 20:00 to 23:59 tomorrow are excluded.

Fixed by setting endDate to midnight of the day after tomorrow, so all 24 hours of the next calendar day are always included.